### PR TITLE
fix: handle missing hivemind modules by returning an empty as result!

### DIFF
--- a/tests/integration/test_data_source_selector.py
+++ b/tests/integration/test_data_source_selector.py
@@ -17,8 +17,8 @@ class TestDataSourceSelector(TestCase):
         test if no community selected hivemind modeules
         """
         selector = DataSourceSelector()
-        with self.assertRaises(ValueError):
-            selector.select_data_source(community_id=self.community_id)
+        data_sources = selector.select_data_source(community_id=self.community_id)
+        self.assertEqual(data_sources, {})
 
     def test_single_platform(self):
         platform_id = "6579c364f1120850414e0da1"

--- a/utils/data_source_selector.py
+++ b/utils/data_source_selector.py
@@ -35,9 +35,8 @@ class DataSourceSelector:
             },
         )
         if hivemind_module is None:
-            raise ValueError(
-                f"No hivemind modules set for the given community id: {community_id}"
-            )
-        platforms = hivemind_module["options"]["platforms"]
+            platforms = {}
+        else:
+            platforms = hivemind_module["options"]["platforms"]
 
         return platforms


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the behavior for data source selection by returning an empty result when no community is selected rather than triggering an error.
- **Tests**
	- Updated test cases to verify that the system gracefully returns an empty output in scenarios with no selected community while maintaining correct behavior for valid selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->