### PR TITLE
feat: Added updating the persisted payload support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ aio_pika==9.4.0
 mongomock==4.2.0.post1
 pydantic==2.9.2
 temporalio==1.9.0
-tc-temporal-backend==1.1.2
+tc-temporal-backend==1.1.3

--- a/temporal_tasks.py
+++ b/temporal_tasks.py
@@ -77,9 +77,11 @@ async def run_hivemind_activity(payload: HivemindQueryPayload):
         },
     )
 
-    # dumping the whole payload of question & answer to db
+    # Get workflow ID and update the payload in the database
+    # If workflow_id is None, insert new data; else update existing document with evaluation results and response
+    workflow_id = getattr(payload, 'workflow_id', None)
     persister = PersistPayload()
-    persister.persist_payload(response_payload)
+    persister.persist_payload(response_payload, workflow_id=workflow_id)
 
     # Hardcoded threshold for answer relevance
     # if the relevance score is less than 3, we do not return the answer

--- a/tests/integration/test_persist_payload.py
+++ b/tests/integration/test_persist_payload.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch
+import copy
 
 import mongomock
 from bson import ObjectId
@@ -122,7 +123,7 @@ class TestPersistPayloadIntegration(unittest.TestCase):
         workflow_id = "507f1f77bcf86cd799439011"  # Valid ObjectId format
 
         # First, insert an initial document with the workflow_id and existing metadata
-        initial_data = self.sample_payload_data.copy()
+        initial_data = copy.deepcopy(self.sample_payload_data)
         initial_data["_id"] = ObjectId(workflow_id)
         initial_data["response"]["message"] = "Initial response"
         initial_data["metadata"] = {"existing_key": "existing_value", "timestamp": "2023-10-08T12:00:00"}
@@ -252,7 +253,7 @@ class TestPersistPayloadIntegration(unittest.TestCase):
     def test_persist_http_update(self):
         """Test updating an existing HTTPPayload document in the database."""
         # Insert an initial HTTP payload document into the mock database
-        initial_data = self.sample_http_payload_data.copy()
+        initial_data = copy.deepcopy(self.sample_http_payload_data)
         initial_data["response"]["message"] = "Not Found"  # Initial message
         self.mock_client["hivemind"]["http_messages"].insert_one(initial_data)
 


### PR DESCRIPTION
in case a workflow id is provided, we will update the payload. otherwise, we will insert the new payload as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved payload persistence to support updating existing documents when a workflow ID is provided, including merging metadata and handling timestamps.
- **Bug Fixes**
	- Ensured correct behavior when inserting or updating documents based on the presence of a workflow ID.
- **Tests**
	- Added new integration tests to verify document insertion, updating, and metadata merging with and without a workflow ID.
- **Chores**
	- Updated a dependency version for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->